### PR TITLE
Detection of Skeletons and Animations in the Object Analyzer

### DIFF
--- a/Z64 Utils/App.config
+++ b/Z64 Utils/App.config
@@ -1,37 +1,37 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="OpenTK" publicKeyToken="bad199fe84eb3df4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
+        <assemblyIdentity name="OpenTK" publicKeyToken="bad199fe84eb3df4" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Z64 Utils/Common/ArrayUtil.cs
+++ b/Z64 Utils/Common/ArrayUtil.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Z64.Common
+{
+    class ArrayUtil
+    {
+        public static uint ReadUint32BE(byte[] data, int offset = 0)
+        {
+            byte[] buff = new byte[sizeof(uint)];
+            Buffer.BlockCopy(data, offset, buff, 0, sizeof(uint));
+            return BitConverter.ToUInt32(buff.Reverse().ToArray(), 0);
+        }
+
+        public static short ReadInt16BE(byte[] data, int offset = 0)
+        {
+            byte[] buff = new byte[sizeof(short)];
+            Buffer.BlockCopy(data, offset, buff, 0, sizeof(short));
+            return BitConverter.ToInt16(buff.Reverse().ToArray(), 0);
+        }
+
+        public static ushort ReadUInt16BE(byte[] data, int offset = 0)
+        {
+            byte[] buff = new byte[sizeof(ushort)];
+            Buffer.BlockCopy(data, offset, buff, 0, sizeof(ushort));
+            return BitConverter.ToUInt16(buff.Reverse().ToArray(), 0);
+        }
+    }
+}

--- a/Z64 Utils/Forms/AnalyzerSettingsForm.Designer.cs
+++ b/Z64 Utils/Forms/AnalyzerSettingsForm.Designer.cs
@@ -51,7 +51,7 @@
             this.textBoxOpCodeList.Name = "textBoxOpCodeList";
             this.textBoxOpCodeList.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.textBoxOpCodeList.Size = new System.Drawing.Size(458, 107);
-            this.textBoxOpCodeList.TabIndex = 0;
+            this.textBoxOpCodeList.TabIndex = 8;
             this.textBoxOpCodeList.WordWrap = false;
             this.textBoxOpCodeList.TextChanged += new System.EventHandler(this.textBoxOpCodeList_TextChanged);
             // 
@@ -130,7 +130,7 @@
             this.buttonOK.Location = new System.Drawing.Point(207, 457);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 8;
+            this.buttonOK.TabIndex = 0;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);

--- a/Z64 Utils/Forms/ObjectAnalyzerForm.Designer.cs
+++ b/Z64 Utils/Forms/ObjectAnalyzerForm.Designer.cs
@@ -64,6 +64,8 @@
             this.addToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportCToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.findDlistsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.analyzeDlistsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -74,8 +76,6 @@
             this.disassemblySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exportCToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.tabPage3.SuspendLayout();
@@ -97,11 +97,11 @@
             this.tabControl1.Controls.Add(this.tabPage4);
             this.tabControl1.Controls.Add(this.tabPage5);
             this.tabControl1.ItemSize = new System.Drawing.Size(47, 18);
-            this.tabControl1.Location = new System.Drawing.Point(287, 27);
+            this.tabControl1.Location = new System.Drawing.Point(377, 27);
             this.tabControl1.MinimumSize = new System.Drawing.Size(357, 207);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(644, 499);
+            this.tabControl1.Size = new System.Drawing.Size(632, 499);
             this.tabControl1.TabIndex = 8;
             // 
             // tabPage1
@@ -109,7 +109,7 @@
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(636, 473);
+            this.tabPage1.Size = new System.Drawing.Size(624, 473);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "nothing";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -120,7 +120,7 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(636, 473);
+            this.tabPage2.Size = new System.Drawing.Size(624, 473);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "ucode";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -136,7 +136,7 @@
             this.ucodeTextBox.Name = "ucodeTextBox";
             this.ucodeTextBox.ReadOnly = true;
             this.ucodeTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.ucodeTextBox.Size = new System.Drawing.Size(622, 461);
+            this.ucodeTextBox.Size = new System.Drawing.Size(617, 461);
             this.ucodeTextBox.TabIndex = 7;
             this.ucodeTextBox.WordWrap = false;
             // 
@@ -146,7 +146,7 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(636, 473);
+            this.tabPage3.Size = new System.Drawing.Size(624, 473);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "texture";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -160,7 +160,7 @@
             this.pic_texture.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
             this.pic_texture.Location = new System.Drawing.Point(6, 6);
             this.pic_texture.Name = "pic_texture";
-            this.pic_texture.Size = new System.Drawing.Size(622, 461);
+            this.pic_texture.Size = new System.Drawing.Size(617, 461);
             this.pic_texture.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pic_texture.TabIndex = 0;
             this.pic_texture.TabStop = false;
@@ -171,7 +171,7 @@
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(636, 473);
+            this.tabPage4.Size = new System.Drawing.Size(624, 473);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "vertex";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -194,7 +194,7 @@
             listViewItem1});
             this.listView_vtx.Location = new System.Drawing.Point(6, 6);
             this.listView_vtx.Name = "listView_vtx";
-            this.listView_vtx.Size = new System.Drawing.Size(624, 461);
+            this.listView_vtx.Size = new System.Drawing.Size(619, 461);
             this.listView_vtx.TabIndex = 0;
             this.listView_vtx.UseCompatibleStateImageBehavior = false;
             this.listView_vtx.View = System.Windows.Forms.View.Details;
@@ -230,7 +230,7 @@
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(636, 473);
+            this.tabPage5.Size = new System.Drawing.Size(624, 473);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "unknow";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -247,7 +247,7 @@
             this.hexBox1.Name = "hexBox1";
             this.hexBox1.ReadOnly = true;
             this.hexBox1.ShadowSelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(60)))), ((int)(((byte)(188)))), ((int)(((byte)(255)))));
-            this.hexBox1.Size = new System.Drawing.Size(627, 461);
+            this.hexBox1.Size = new System.Drawing.Size(622, 461);
             this.hexBox1.StringViewVisible = true;
             this.hexBox1.TabIndex = 1;
             this.hexBox1.UseFixedBytesPerLine = true;
@@ -270,7 +270,7 @@
             this.listView_map.Location = new System.Drawing.Point(12, 27);
             this.listView_map.MultiSelect = false;
             this.listView_map.Name = "listView_map";
-            this.listView_map.Size = new System.Drawing.Size(269, 499);
+            this.listView_map.Size = new System.Drawing.Size(359, 499);
             this.listView_map.TabIndex = 7;
             this.listView_map.UseCompatibleStateImageBehavior = false;
             this.listView_map.View = System.Windows.Forms.View.Details;
@@ -284,12 +284,12 @@
             // columnHeader2
             // 
             this.columnHeader2.Text = "Name";
-            this.columnHeader2.Width = 131;
+            this.columnHeader2.Width = 151;
             // 
             // columnHeader3
             // 
             this.columnHeader3.Text = "Type";
-            this.columnHeader3.Width = 56;
+            this.columnHeader3.Width = 124;
             // 
             // contextMenuStrip1
             // 
@@ -329,9 +329,24 @@
             this.settingsToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(931, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(1009, 24);
             this.menuStrip1.TabIndex = 9;
             this.menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exportCToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "File";
+            // 
+            // exportCToolStripMenuItem
+            // 
+            this.exportCToolStripMenuItem.Name = "exportCToolStripMenuItem";
+            this.exportCToolStripMenuItem.Size = new System.Drawing.Size(119, 22);
+            this.exportCToolStripMenuItem.Text = "Export C";
+            this.exportCToolStripMenuItem.Click += new System.EventHandler(this.exportCToolStripMenuItem_Click);
             // 
             // toolsToolStripMenuItem
             // 
@@ -348,35 +363,37 @@
             // findDlistsToolStripMenuItem
             // 
             this.findDlistsToolStripMenuItem.Name = "findDlistsToolStripMenuItem";
-            this.findDlistsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.findDlistsToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+F";
+            this.findDlistsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.findDlistsToolStripMenuItem.Text = "Find Dlists";
             this.findDlistsToolStripMenuItem.Click += new System.EventHandler(this.findDlistsToolStripMenuItem_Click);
             // 
             // analyzeDlistsToolStripMenuItem
             // 
             this.analyzeDlistsToolStripMenuItem.Name = "analyzeDlistsToolStripMenuItem";
-            this.analyzeDlistsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.analyzeDlistsToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+A";
+            this.analyzeDlistsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.analyzeDlistsToolStripMenuItem.Text = "Analyze Dlists";
             this.analyzeDlistsToolStripMenuItem.Click += new System.EventHandler(this.analyzeDlistsToolStripMenuItem_Click);
             // 
             // importJSONToolStripMenuItem
             // 
             this.importJSONToolStripMenuItem.Name = "importJSONToolStripMenuItem";
-            this.importJSONToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.importJSONToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.importJSONToolStripMenuItem.Text = "Import JSON";
             this.importJSONToolStripMenuItem.Click += new System.EventHandler(this.importJSONToolStripMenuItem_Click);
             // 
             // exportJSONToolStripMenuItem
             // 
             this.exportJSONToolStripMenuItem.Name = "exportJSONToolStripMenuItem";
-            this.exportJSONToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportJSONToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.exportJSONToolStripMenuItem.Text = "Export JSON";
             this.exportJSONToolStripMenuItem.Click += new System.EventHandler(this.exportJSONToolStripMenuItem_Click);
             // 
             // resetToolStripMenuItem
             // 
             this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
-            this.resetToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.resetToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.resetToolStripMenuItem.Text = "Reset";
             this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
             // 
@@ -399,30 +416,16 @@
             // 
             this.openFileDialog1.FileName = "openFileDialog1";
             // 
-            // fileToolStripMenuItem
-            // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.exportCToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "File";
-            // 
-            // exportCToolStripMenuItem
-            // 
-            this.exportCToolStripMenuItem.Name = "exportCToolStripMenuItem";
-            this.exportCToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.exportCToolStripMenuItem.Text = "Export C";
-            this.exportCToolStripMenuItem.Click += new System.EventHandler(this.exportCToolStripMenuItem_Click);
-            // 
             // ObjectAnalyzerForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(931, 528);
+            this.ClientSize = new System.Drawing.Size(1009, 528);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.listView_map);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "ObjectAnalyzerForm";
             this.Text = "Object Analyzer";

--- a/Z64 Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64 Utils/Forms/ObjectAnalyzerForm.cs
@@ -45,6 +45,34 @@ namespace Z64.Forms
             UpdateMap();
         }
 
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == (Keys.Control | Keys.F))
+            {
+                var form = new AnalyzerSettingsForm();
+                if (form.ShowDialog() == DialogResult.OK)
+                {
+                    Z64ObjectAnalyzer.FindDlists(_obj, _data, _segment, form.Result);
+                    UpdateMap();
+                }
+                return true;
+            }
+            else if (keyData == (Keys.Control | Keys.A))
+            {
+                var errors = Z64ObjectAnalyzer.AnalyzeDlists(_obj, _data, _segment);
+                if (errors.Count > 0)
+                {
+                    StringWriter sw = new StringWriter();
+                    errors.ForEach(error => sw.WriteLine(error));
+                    TextForm form = new TextForm(SystemIcons.Warning, "Warning", sw.ToString());
+                    form.ShowDialog();
+                }
+                UpdateMap();
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
         public void UpdateDisassembly()
         {
             var dlist = GetCurrentHolder<Z64Object.DListHolder>();
@@ -140,6 +168,13 @@ namespace Z64.Forms
                         break;
                     }
                 case Z64Object.EntryType.Unknown:
+                case Z64Object.EntryType.SkeletonHeader:
+                case Z64Object.EntryType.FlexSkeletonHeader:
+                case Z64Object.EntryType.SkeletonLimb:
+                case Z64Object.EntryType.SkeletonLimbs:
+                case Z64Object.EntryType.AnimationHeader:
+                case Z64Object.EntryType.FrameData:
+                case Z64Object.EntryType.JointIndices:
                     {
                         tabControl1.SelectedIndex = 4;
 

--- a/Z64 Utils/Forms/TextForm.Designer.cs
+++ b/Z64 Utils/Forms/TextForm.Designer.cs
@@ -45,6 +45,7 @@
             this.textBox1.Size = new System.Drawing.Size(776, 426);
             this.textBox1.TabIndex = 0;
             this.textBox1.WordWrap = false;
+            this.textBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextForm_KeyDown);
             // 
             // TextForm
             // 

--- a/Z64 Utils/Forms/TextForm.cs
+++ b/Z64 Utils/Forms/TextForm.cs
@@ -19,5 +19,13 @@ namespace Z64.Forms
             Text = title;
             textBox1.Text = message;
         }
+
+        private void TextForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape || e.KeyCode == Keys.Enter)
+            {
+                this.Close();
+            }
+        }
     }
 }

--- a/Z64 Utils/Properties/Resources.Designer.cs
+++ b/Z64 Utils/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Z64.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Z64 Utils/Properties/Settings.Designer.cs
+++ b/Z64 Utils/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Z64.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Z64 Utils/Z64 Utils.csproj
+++ b/Z64 Utils/Z64 Utils.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -95,6 +96,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\ArrayUtil.cs" />
     <Compile Include="Common\Filters.cs" />
     <Compile Include="Common\UpdateChecker.cs" />
     <Compile Include="FolderSelectDialog.cs">

--- a/Z64 Utils/Z64/Z64Object.cs
+++ b/Z64 Utils/Z64/Z64Object.cs
@@ -218,7 +218,7 @@ namespace Z64
             {
                 Raw = data;
                 if ((data.Length % 4) != 0)
-                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 4");
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X}) should be a multiple of 4");
 
                 LimbSegments = new SegmentedAddress[data.Length / 4];
                 for (int i = 0; i < data.Length/4; i++)
@@ -336,7 +336,7 @@ namespace Z64
             {
                 Raw = data;
                 if ((data.Length % 2) != 0)
-                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 2");
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X}) should be a multiple of 2");
 
                 FrameData = new short[data.Length / 2];
                 for (int i = 0; i < data.Length / 2; i++)
@@ -371,7 +371,7 @@ namespace Z64
             {
                 Raw = data;
                 if ((data.Length % 6) != 0)
-                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 6");
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X}) should be a multiple of 6");
 
                 JointIndices = new JointIndex[data.Length / 6];
                 for (int i = 0; i < data.Length / 6; i++)

--- a/Z64 Utils/Z64/Z64Object.cs
+++ b/Z64 Utils/Z64/Z64Object.cs
@@ -11,6 +11,8 @@ using N64;
 using RDP;
 using Syroot.BinaryData;
 using Common;
+using System.Runtime.Remoting.Messaging;
+using Z64.Common;
 
 namespace Z64
 {
@@ -33,6 +35,13 @@ namespace Z64
             DList,
             Vertex,
             Texture,
+            AnimationHeader,
+            FrameData,
+            JointIndices,
+            SkeletonHeader,
+            FlexSkeletonHeader,
+            SkeletonLimbs,
+            SkeletonLimb,
             Unknown,
         }
 
@@ -154,6 +163,229 @@ namespace Z64
                 Texture = data;
             }
             public override int GetSize() => Texture.Length;
+        }
+        public class SkeletonLimbHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+
+            public short JointX { get; set; }
+            public short JointY { get; set; }
+            public short JointZ { get; set; }
+            public byte Parent { get; set; }
+            public byte Child { get; set; }
+            public SegmentedAddress DListSeg { get; set; }
+
+            public SkeletonLimbHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.SkeletonLimb;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                JointX = ArrayUtil.ReadInt16BE(data, 0);
+                JointY = ArrayUtil.ReadInt16BE(data, 2);
+                JointZ = ArrayUtil.ReadInt16BE(data, 4);
+                Parent = data[6];
+                Child = data[7];
+                DListSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, 8));
+            }
+            public override int GetSize() => Raw.Length;
+        }
+        public class SkeletonLimbsHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+
+            public SegmentedAddress[] LimbSegments { get; set; }
+
+            public SkeletonLimbsHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.SkeletonLimbs;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                if ((data.Length % 4) != 0)
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 4");
+
+                LimbSegments = new SegmentedAddress[data.Length / 4];
+                for (int i = 0; i < data.Length/4; i++)
+                {
+                    LimbSegments[i] = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, i * 4));
+                }
+            }
+            public override int GetSize() => Raw.Length;
+        }
+        public class SkeletonHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+            
+            public int LimbCount { get; set; }
+            public SegmentedAddress LimbsSeg { get; set; }
+            
+            public SkeletonHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.SkeletonHeader;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                LimbsSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(data));
+                LimbCount = data[4];
+            }
+            public override int GetSize() => Raw.Length;
+
+        }
+
+        public class FlexSkeletonHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+            
+            public int LimbCount { get; set; }
+            public SegmentedAddress LimbsSeg { get; set; }
+            public int DListCount { get; set; }
+
+            public FlexSkeletonHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.FlexSkeletonHeader;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                LimbsSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(data));
+                LimbCount = data[4];
+                DListCount = data[8];
+            }
+            public override int GetSize() => Raw.Length;
+
+        }
+        public class AnimationHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+
+            public short FrameCount { get; set; }
+            public SegmentedAddress FrameData { get; set; }
+            public SegmentedAddress JointIndices { get; set; }
+            public ushort StaticIndexMax { get; set; }
+
+            public AnimationHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.AnimationHeader;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                FrameCount = ArrayUtil.ReadInt16BE(data, 0);
+                FrameData = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, 4));
+                JointIndices = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, 8));
+                StaticIndexMax = ArrayUtil.ReadUInt16BE(data, 12);
+            }
+            public override int GetSize() => Raw.Length;
+        }
+        public class AnimationFrameDataHolder : ObjectHolder
+        {
+            public byte[] Raw { get; set; }
+            
+            public short[] FrameData { get; set; }
+
+            public AnimationFrameDataHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.FrameData;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                if ((data.Length % 2) != 0)
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 2");
+
+                FrameData = new short[data.Length / 2];
+                for (int i = 0; i < data.Length / 2; i++)
+                {
+                    FrameData[i] = ArrayUtil.ReadInt16BE(data, i * 2);
+                }
+            }
+            public override int GetSize() => Raw.Length;
+        }
+        public class AnimationJointIndicesHolder : ObjectHolder
+        {
+            public struct JointIndex
+            {
+                public ushort x, y, z;
+            };
+
+            public byte[] Raw { get; set; }
+            public JointIndex[] JointIndices { get; set; }
+
+            public AnimationJointIndicesHolder(string name, byte[] data) : base(name)
+            {
+                SetData(data);
+            }
+
+            public override byte[] GetData() => Raw;
+
+            public override EntryType GetEntryType()
+            {
+                return EntryType.JointIndices;
+            }
+            public override void SetData(byte[] data)
+            {
+                Raw = data;
+                if ((data.Length % 6) != 0)
+                    throw new Z64ObjectException($"Invalid data size (0x{data.Length:X} should be a multiple of 6");
+
+                JointIndices = new JointIndex[data.Length / 6];
+                for (int i = 0; i < data.Length / 6; i++)
+                {
+                    JointIndices[i] = 
+                        new JointIndex() {
+                            x = ArrayUtil.ReadUInt16BE(data, i * 6),
+                            y = ArrayUtil.ReadUInt16BE(data, i * 6 + 2),
+                            z = ArrayUtil.ReadUInt16BE(data, i * 6 + 4)
+                        };
+                }
+            }
+            public override int GetSize() => Raw.Length;
         }
 
         public List<ObjectHolder> Entries { get; set; }
@@ -374,21 +606,88 @@ namespace Z64
             AddVertexHolder(holder, off);
             return holder;
         }
-
+        public SkeletonLimbHolder AddSkeletonLimb(int size, string name = null, int off = -1, int skel_off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new SkeletonLimbHolder(name?? $"skel_{skel_off:X8}_limb_{off:X8}", new byte[size]);
+            return (SkeletonLimbHolder)AddHolder(holder, off);
+        }
+        public SkeletonLimbsHolder AddSkeletonLimbs(int size, string name = null, int off = -1, int skel_off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new SkeletonLimbsHolder(name?? $"skel_{skel_off:X8}_limbs_{off:X8}", new byte[size]);
+            return (SkeletonLimbsHolder)AddHolder(holder, off);
+        }
+        public SkeletonHolder AddSkeleton(int size, string name = null, int off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new SkeletonHolder(name?? $"skel_{off:X8}", new byte[size]);
+            return (SkeletonHolder)AddHolder(holder, off);
+        }
+        public FlexSkeletonHolder AddFlexSkeleton(int size, string name = null, int off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new FlexSkeletonHolder(name ?? $"skel_{off:X8}", new byte[size]);
+            return (FlexSkeletonHolder)AddHolder(holder, off);
+        }
+        public AnimationHolder AddAnimation(int size, string name = null, int off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new AnimationHolder(name?? $"anim_{off:X8}", new byte[size]);
+            return (AnimationHolder)AddHolder(holder, off);
+        }
+        public AnimationFrameDataHolder AddFrameData(int size, string name = null, int off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new AnimationFrameDataHolder(name ?? $"framedata_{off:X8}", new byte[size]);
+            return (AnimationFrameDataHolder)AddHolder(holder, off);
+        }
+        public AnimationJointIndicesHolder AddJointIndices(int size, string name = null, int off = -1)
+        {
+            if (off == -1) off = GetSize();
+            var holder = new AnimationJointIndicesHolder(name ?? $"jointindices_{off:X8}", new byte[size]);
+            return (AnimationJointIndicesHolder)AddHolder(holder, off);
+        }
 
         public void FixNames()
         {
             int entryOff = 0;
             foreach (var entry in Entries)
             {
-                entry.Name = (entry.GetEntryType() == EntryType.DList
-                    ? "dlist_"
-                    : entry.GetEntryType() == EntryType.Texture
-                        ? "tex_"
-                        : entry.GetEntryType() == EntryType.Vertex
-                            ? "vtx_"
-                            : "unk_") + entryOff.ToString("X8");
-
+                switch (entry.GetEntryType())
+                {
+                    case EntryType.AnimationHeader:
+                        entry.Name = "anim_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.FrameData:
+                        entry.Name = "framedata_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.JointIndices:
+                        entry.Name = "jointindices_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.SkeletonHeader:
+                    case EntryType.FlexSkeletonHeader:
+                        entry.Name = "skel_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.SkeletonLimbs:
+                        entry.Name = "limbs_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.SkeletonLimb:
+                        entry.Name = "limb_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.DList:
+                        entry.Name = "dlist_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.Texture:
+                        entry.Name = "tex_" + entryOff.ToString("X8");
+                        break;
+                    case EntryType.Vertex:
+                        entry.Name = "vtx_" + entryOff.ToString("X8");
+                        break;
+                    default:
+                        entry.Name = "unk_" + entryOff.ToString("X8");
+                        break;
+                }
                 entryOff += entry.GetSize();
             }
             foreach (var entry in Entries)

--- a/Z64 Utils/Z64/Z64Object.cs
+++ b/Z64 Utils/Z64/Z64Object.cs
@@ -11,7 +11,6 @@ using N64;
 using RDP;
 using Syroot.BinaryData;
 using Common;
-using System.Runtime.Remoting.Messaging;
 using Z64.Common;
 
 namespace Z64

--- a/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
+++ b/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
@@ -431,7 +431,7 @@ namespace Z64
                         if ((jointIndicesSize % 6) != 0)
                         {
                             byte[] possiblePadding = new byte[jointIndicesSize % 6];
-                            Buffer.BlockCopy(data, (int)(jointIndicesSeg.SegmentOff + jointIndicesSize - (jointIndicesSize % 2)),
+                            Buffer.BlockCopy(data, (int)(jointIndicesSeg.SegmentOff + jointIndicesSize - (jointIndicesSize % 6)),
                                 possiblePadding, 0, jointIndicesSize % 6);
                             // if assumed struct padding is nonzero, consider invalid
                             if (possiblePadding.Any(b => b != 0))

--- a/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
+++ b/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
@@ -431,7 +431,7 @@ namespace Z64
                         if ((jointIndicesSize % 6) != 0)
                         {
                             byte[] possiblePadding = new byte[jointIndicesSize % 6];
-                            Buffer.BlockCopy(data, (int)(frameDataSeg.SegmentOff + jointIndicesSize - (jointIndicesSize % 2)),
+                            Buffer.BlockCopy(data, (int)(jointIndicesSeg.SegmentOff + jointIndicesSize - (jointIndicesSize % 2)),
                                 possiblePadding, 0, jointIndicesSize % 6);
                             // if assumed struct padding is nonzero, consider invalid
                             if (possiblePadding.Any(b => b != 0))

--- a/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
+++ b/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
@@ -8,6 +8,7 @@ using RDP;
 using N64;
 using System.Text.RegularExpressions;
 using System.IO;
+using Z64.Common;
 
 namespace Z64
 {
@@ -330,7 +331,95 @@ namespace Z64
                     return Math.Max(i, texels / i);
             return 0;
         }
-        
+
+        public static void FindSkeletons(Z64Object obj, byte[] data, int segmentId)
+        {
+            const int SKELETON_HEADER_SIZE = 0x8;
+            const int FLEX_SKELETON_HEADER_SIZE = SKELETON_HEADER_SIZE + 0x4;
+            const int SKELETON_LIMB_SIZE = 0xC; // only supports StandardLimb so far
+            // Search for Skeleton Headers
+            // Structure: SS OO OO OO XX 00 00 00 [XX 00 00 00]
+            for (int i = 0; i < data.Length - SKELETON_HEADER_SIZE; i += 4)
+            {
+                var segment = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, i));
+                // check for segmentId match, check for valid segment offset,
+                // check for Limbs 0x4 alignment, check for nonzero limb count,
+                // check for zeroes in struct padding
+                if (segment.SegmentId == segmentId && segment.SegmentOff < data.Length && 
+                    (segment.SegmentOff % 4) == 0 && data[i+4] != 0 &&
+                    data[i + 5] == 0 && data[i + 6] == 0 && data[i + 7] == 0)
+                {
+                    if (!obj.IsOffsetFree(i))
+                        continue;
+                    
+                    int nLimbs = data[i + 4];
+                    byte[] limbsData = new byte[nLimbs * 4];
+                    Buffer.BlockCopy(data, (int)segment.SegmentOff, limbsData, 0, nLimbs * 4);
+                    // check for limbs array ending at the start of the skeleton header,
+                    // check for limbs array's segmented addresses being 0xC apart from one another
+                    if (segment.SegmentOff + nLimbs * 4 == i &&
+                        ArrayUtil.ReadUint32BE(limbsData, 4) - ArrayUtil.ReadUint32BE(limbsData, 0) == SKELETON_LIMB_SIZE)
+                    {
+                        int nNonNullDlists = 0;
+                        obj.AddSkeletonLimbs(nLimbs * 4, off: (int)segment.SegmentOff);
+                        for (int j = 0; j < nLimbs * 4; j += 4)
+                        {
+                            SegmentedAddress limbSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(limbsData, j));
+                            if (limbSeg.SegmentId != segmentId)
+                                throw new Z64ObjectAnalyzerException(
+                                    $"Limb segment {limbSeg.Segmented} is not the correct segment id, mis-detected SkeletonHeader?");
+                            obj.AddSkeletonLimb(SKELETON_LIMB_SIZE, off: (int)limbSeg.SegmentOff);
+                            // check if dlist is non-null (dlists may be null in general, this is only for FlexSkeletonHeader detection)
+                            if (ArrayUtil.ReadUint32BE(data, (int)(limbSeg.SegmentOff + 0x8)) != 0)
+                                nNonNullDlists++;
+                        }
+                        // try to detect flex headers over normal headers
+                        // check for the existence of extra bytes beyond standard header size,
+                        // check if nothing is already assumed to occupy that space,
+                        // check if the number of dlists is equal to the actual number of non-null dlists,
+                        // check struct padding
+                        if (i < data.Length - FLEX_SKELETON_HEADER_SIZE && obj.IsOffsetFree(i + SKELETON_HEADER_SIZE) &&
+                            data[i + 8] == nNonNullDlists && data[i + 9] == 0 && data[i + 10] == 0 && data[i + 11] == 0)
+                        {
+                            obj.AddFlexSkeleton(FLEX_SKELETON_HEADER_SIZE, off: i);
+                        }
+                        else
+                        {
+                            obj.AddSkeleton(SKELETON_HEADER_SIZE, off: i);
+                        }
+                    }
+                }
+            }
+        }
+        public static void FindAnimations(Z64Object obj, byte[] data, int segmentId)
+        {
+            const int ANIMATION_HEADER_SIZE = 0x10;
+            // Search for Animation Headers
+            // Structure: FF FF 00 00 SS OO OO OO SS OO OO OO II II 00 00
+            for (int i = 0; i < data.Length - ANIMATION_HEADER_SIZE; i += 4)
+            {
+                var frameCount = ArrayUtil.ReadInt16BE(data, i);
+                // check positive nonzero frame count, check struct padding zeroes
+                if (frameCount > 0 &&
+                    data[i + 2] == 0 && data[i + 3] == 0 && data[i + 14] == 0 && data[i + 15] == 0)
+                {
+                    if (!obj.IsOffsetFree(i))
+                        continue;
+                    
+                    var frameDataSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, i+4));
+                    var jointIndicesSeg = new SegmentedAddress(ArrayUtil.ReadUint32BE(data, i+8));
+                    // check for segmentId match, check for valid segment offsets
+                    if (frameDataSeg.SegmentId == segmentId && jointIndicesSeg.SegmentId == segmentId &&
+                        frameDataSeg.SegmentOff < data.Length && jointIndicesSeg.SegmentOff < data.Length)
+                    {
+                        obj.AddAnimation(ANIMATION_HEADER_SIZE, off: i);
+                        // Assumes these are all in order and end at the start of the next, which seems to be the case so far
+                        obj.AddFrameData((int)(jointIndicesSeg.SegmentOff - frameDataSeg.SegmentOff), off:(int)frameDataSeg.SegmentOff);
+                        obj.AddJointIndices((int)(i - jointIndicesSeg.SegmentOff), off:(int)jointIndicesSeg.SegmentOff);
+                    }
+                }
+            }
+        }
 
         public static void FindDlists(Z64Object obj, byte[] data, int segmentId, Config cfg)
         {
@@ -493,6 +582,11 @@ namespace Z64
                 }
             }
 
+            // These are carried out here as they are dependent on a lot of heuristics.
+            // Having lots of the object already mapped out reduces possible mis-identifications.
+            FindSkeletons(obj, data, segmentId);
+            FindAnimations(obj, data, segmentId);
+            
             obj.GroupUnkEntries();
             obj.FixNames();
             obj.SetData(data);


### PR DESCRIPTION
Adds automatic detection of SkeletonHeaders and AnimationHeaders, as well as the data they reference
- Implemented detection routines based on a set of heuristics (see comments in Z64ObjectAnalyzer.cs)
- Created Holders for the new types of data.
- Resized the Object Analyzer Form as some of the new types have long names (longest being `FlexSkeletonHeader`) that did not fit well with the current size.

From testing, the methods employed to find SkeletonHeaders and AnimationHeaders appear effective and have not yet caused mis-identifications. This may be in part due to their detection being delayed until after much of the object has already been mapped out through the Display List analysis. Trying it on `gameplay_keep` returns fully accurate results as far as is known.

Small Quality of Life changes:
- Added keyboard shortcuts for `Find DLists` (`Ctrl+F`) and `Analyze DLists` (`Ctrl+A`)
- Added a keyboard shortcut to close the Error Form (`Enter` or `Escape`)
- Swapped the tab indexes in the Analyzer Settings Form so the OK button has focus when the window opens. This lets you hit enter to proceed with the normal settings right away.
