### PR TITLE
Mtx detection

### DIFF
--- a/Z64 Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64 Utils/Forms/ObjectAnalyzerForm.cs
@@ -12,6 +12,7 @@ using System.Windows.Forms;
 using RDP;
 using Be.Windows.Forms;
 using Common;
+using Z64.Common;
 
 namespace Z64.Forms
 {
@@ -183,7 +184,7 @@ namespace Z64.Forms
                                 var values = "";
                                 for (int j = 0; j < 4; j++)
                                 {
-                                    values += $"0x{matrices.Matrices[n][i * 4 + j]:X08}";
+                                    values += $"0x{ArrayUtil.ReadUint32BE(matrices.Matrices[n].GetBuffer(), 4*(4 * i + j)):X08}";
                                     if (j != 3)
                                         values += $"  ";
                                 }

--- a/Z64 Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64 Utils/Forms/ObjectAnalyzerForm.cs
@@ -170,6 +170,30 @@ namespace Z64.Forms
                             pic_texture.Image = tex.GetBitmap();
                         break;
                     }
+                case Z64Object.EntryType.Mtx:
+                    {
+                        tabControl1.SelectedTab = tabPage_text;
+                        var matrices = (Z64Object.MtxHolder)holder;
+                        StringWriter sw = new StringWriter();
+                        for (int n = 0; n < matrices.Matrices.Count; n++)
+                        {
+                            sw.WriteLine($" ┌                                                ┐ ");
+                            for (int i = 0; i < 4; i++)
+                            {
+                                var values = "";
+                                for (int j = 0; j < 4; j++)
+                                {
+                                    values += $"0x{matrices.Matrices[n][i * 4 + j]:X08}";
+                                    if (j != 3)
+                                        values += $"  ";
+                                }
+                                sw.WriteLine($" │ {values} │ ");
+                            }
+                            sw.WriteLine($" └                                                ┘ ");
+                        }
+                        textBox_holderInfo.Text = sw.ToString();
+                        break;
+                    }
                 case Z64Object.EntryType.SkeletonHeader:
                     {
                         showInDisplayViewerToolStripMenuItem.Visible = true;

--- a/Z64 Utils/Z64/Z64Object.cs
+++ b/Z64 Utils/Z64/Z64Object.cs
@@ -738,7 +738,7 @@ namespace Z64
         public MtxHolder AddMtx(int mtxCount, string name = null, int off = -1)
         {
             if (off == -1) off = GetSize();
-            var holder = new MtxHolder(name ?? $"mtx_{off:X8}", new byte[mtxCount * 0x40]);
+            var holder = new MtxHolder(name ?? $"mtx_{off:X8}", new byte[mtxCount * MtxHolder.MTX_SIZE]);
             return (MtxHolder)AddHolder(holder, off);
         }
         public SkeletonLimbHolder AddSkeletonLimb(string name = null, int off = -1, int skel_off = -1)

--- a/Z64 Utils/Z64/Z64Object.cs
+++ b/Z64 Utils/Z64/Z64Object.cs
@@ -181,7 +181,7 @@ namespace Z64
                     BinaryStream bw = new BinaryStream(ms, ByteConverter.Big);
                     foreach (Mtx mtx in Matrices)
                     {
-                        bw.Write(mtx.GetBuffer());
+                        mtx.Write(bw);
                     }
                     return ms.ToArray().Take((int)ms.Length).ToArray();
                 }
@@ -191,14 +191,16 @@ namespace Z64
                 if (data.Length % Mtx.SIZE != 0)
                     throw new Z64ObjectException($"Invalid data size (0x{data.Length:X}, should be a multiple of 0x{Mtx.SIZE:X})");
 
-                int nMatrices = data.Length / Mtx.SIZE;
-                Matrices = new List<Mtx>(nMatrices);
-                
-                for (int i = 0; i < nMatrices; i++)
+                int count = data.Length / Mtx.SIZE;
+
+                Matrices = new List<Mtx>(count);
+                using (MemoryStream ms = new MemoryStream(data))
                 {
-                    byte[] mtxData = new byte[Mtx.SIZE];
-                    Buffer.BlockCopy(data, i * Mtx.SIZE, mtxData, 0, Mtx.SIZE);
-                    Matrices.Add(new Mtx(mtxData));
+                    BinaryStream br = new BinaryStream(ms);
+                    br.ByteConverter = ByteConverter.Big;
+
+                    for (int i = 0; i < count; i++)
+                        Matrices.Add(new Mtx(br));
                 }
             }
             public override int GetSize() => Matrices.Count * Mtx.SIZE;

--- a/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
+++ b/Z64 Utils/Z64/Z64ObjectAnalyzer.cs
@@ -513,6 +513,16 @@ namespace Z64
                                 exit = true;
                                 break;
                             }
+                        case OpCodeID.G_MTX:
+                            {
+                                var gmtx = F3DZEX.Command.DecodeCommand<F3DZEX.Command.GMtx>(data, i);
+                                var addr = new SegmentedAddress(gmtx.mtxaddr);
+                                if (addr.Segmented && addr.SegmentId == segmentId)
+                                {
+                                    obj.AddMtx(1, off: (int)addr.SegmentOff);
+                                }
+                                break;
+                            }
                         case OpCodeID.G_VTX:
                             {
                                 var gvtx = F3DZEX.Command.DecodeCommand<F3DZEX.Command.GVtx>(data, i);


### PR DESCRIPTION
Adds in-object Mtx detection to the object analyzer. Based on skel viewer progress to make use of `G_MTX` command decoding.
If the Mtx could be represented better in the holder feel free to let me know if you want me to make any changes.

For an example of where this is applicable see `object_link_child` (`01352000`) in MM Debug.
 - Mtx at `0601DA98` referenced by DList at `0601DAD8`
 - Mtx at `0601DB00` referenced by DList at `0601DB40`

The matrices are represented like so:
(For multiple matrices the next would be below, however the current detection only ever outputs one matrix)

![mtx](https://user-images.githubusercontent.com/17233964/107714112-97bbf700-6cc4-11eb-87b3-5307f60c99a1.PNG)
