### PR TITLE
Add crappy compatibility to ZAPD's xmls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+
+# VS Code
+.vscode/

--- a/Z64Utils/Common/Filters.cs
+++ b/Z64Utils/Common/Filters.cs
@@ -13,6 +13,7 @@ namespace Common
         public const string N64 = "N64 Rom(*.n64; *.z64)|*.n64;*.z64";
         public const string BIN = "Bin Files (*.bin)|*.bin";
         public const string JSON = "JSON Files (*.json)|*.json";
+        public const string XML = "XML Files (*.xml)|*.xml";
         public const string C = "C Files (*.c)|*.c";
     }
 }

--- a/Z64Utils/Forms/ObjectAnalyzerForm.Designer.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.Designer.cs
@@ -74,6 +74,8 @@
             this.analyzeDlistsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.importJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importXMLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportXMLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disassemblySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -386,6 +388,8 @@
             this.analyzeDlistsToolStripMenuItem,
             this.importJSONToolStripMenuItem,
             this.exportJSONToolStripMenuItem,
+            this.importXMLToolStripMenuItem,
+            this.exportXMLToolStripMenuItem,
             this.resetToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.Size = new System.Drawing.Size(62, 20);
@@ -420,6 +424,20 @@
             this.exportJSONToolStripMenuItem.Size = new System.Drawing.Size(220, 22);
             this.exportJSONToolStripMenuItem.Text = "Export JSON";
             this.exportJSONToolStripMenuItem.Click += new System.EventHandler(this.exportJSONToolStripMenuItem_Click);
+            // 
+            // importXMLToolStripMenuItem
+            // 
+            this.importXMLToolStripMenuItem.Name = "importXMLToolStripMenuItem";
+            this.importXMLToolStripMenuItem.Size = new System.Drawing.Size(220, 22);
+            this.importXMLToolStripMenuItem.Text = "Import XML";
+            this.importXMLToolStripMenuItem.Click += new System.EventHandler(this.importXMLToolStripMenuItem_Click);
+            // 
+            // exportXMLToolStripMenuItem
+            // 
+            this.exportXMLToolStripMenuItem.Name = "exportXMLToolStripMenuItem";
+            this.exportXMLToolStripMenuItem.Size = new System.Drawing.Size(220, 22);
+            this.exportXMLToolStripMenuItem.Text = "Export XML";
+            this.exportXMLToolStripMenuItem.Click += new System.EventHandler(this.exportXMLToolStripMenuItem_Click);
             // 
             // resetToolStripMenuItem
             // 
@@ -508,6 +526,8 @@
         private System.Windows.Forms.ColumnHeader columnHeader8;
         private System.Windows.Forms.ToolStripMenuItem importJSONToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportJSONToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importXMLToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportXMLToolStripMenuItem;
         private System.Windows.Forms.SaveFileDialog saveFileDialog1;
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;

--- a/Z64Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.cs
@@ -438,6 +438,28 @@ namespace Z64.Forms
             }
         }
 
+        private void importXMLToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            openFileDialog1.FileName = "";
+            openFileDialog1.Filter = $"{Filters.XML}|{Filters.ALL}";
+            if (openFileDialog1.ShowDialog() == DialogResult.OK)
+            {
+                _obj = Z64Object.FromXml(openFileDialog1.FileName);
+                _obj.SetData(_data);
+                UpdateMap();
+            }
+        }
+
+        private void exportXMLToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            saveFileDialog1.FileName = "";
+            saveFileDialog1.Filter = $"{Filters.XML}|{Filters.ALL}";
+            if (saveFileDialog1.ShowDialog() == DialogResult.OK)
+            {
+                _obj.WriteXml(saveFileDialog1.FileName);
+            }
+        }
+
         private void exportCToolStripMenuItem_Click(object sender, EventArgs e)
         {
             saveFileDialog1.FileName = "";

--- a/Z64Utils/Z64/Z64Object.cs
+++ b/Z64Utils/Z64/Z64Object.cs
@@ -1316,108 +1316,99 @@ namespace Z64
 
         public void WriteXml(string filename)
         {
-            /*
+            XmlDocument doc = new XmlDocument();
+            XmlElement root = doc.CreateElement("Root");
+            doc.AppendChild(root);
+
+            XmlElement file = doc.CreateElement("File");
+            // TODO
+            file.SetAttribute("Name", null);
+            file.SetAttribute("Segment", null);
+            root.AppendChild(file);
+
             var list = new List<object>();
             foreach (var iter in Entries)
             {
+                XmlElement child = null;
                 switch (iter.GetEntryType())
                 {
                     case EntryType.DList:
-                        {
-                            list.Add(new JsonUCodeHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Size = iter.GetSize()
-                            });
-                            break;
-                        }
+                        child = doc.CreateElement("DList");
+                        break;
                     case EntryType.Vertex:
-                        {
-                            list.Add(new JsonVertexHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                VertexCount = ((VertexHolder)iter).Vertices.Count,
-                            });
-                            break;
-                        }
+                        child = doc.CreateElement("Vtx");
+                        break;
                     case EntryType.Texture:
                         {
+                            child = doc.CreateElement("Texture");
+
                             var holder = (TextureHolder)iter;
-                            list.Add(new JsonTextureHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Width = holder.Width,
-                                Height = holder.Height,
-                                Format = holder.Format,
-                                Tlut = holder.Tlut?.Name,
-                            });
+                            child.SetAttribute("OutName", iter.Name); // TODO
+                            child.SetAttribute("Format", holder.Format.ToString()); // TODO
+                            child.SetAttribute("Width", holder.Width.ToString());
+                            child.SetAttribute("Height", holder.Height.ToString());
                             break;
                         }
                     case EntryType.Unknown:
-                        {
-                            list.Add(new JsonUnknowHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Size = iter.GetSize()
-                            });
-                            break;
-                        }
+                        child = doc.CreateElement("Blob");
+                        child.SetAttribute("Size", iter.GetSize().ToString());
+                        break;
                     case EntryType.SkeletonLimbs:
                         {
+                            continue;
+                            /*
+                            child = doc.CreateElement("Array");
+                            // I think ZAPD doesn't support this right now, but maybe in the future ?
+                            var subChild = doc.CreateElement("Limb");
+
                             var holder = (SkeletonLimbsHolder)iter;
-                            list.Add(new JsonArrayHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Count = holder.LimbSegments.Length
-                            });
-                            break;
+                            child.SetAttribute("Count", holder.LimbSegments.Length.ToString());
+                            child.AppendChild(subChild);
+                            */
+                            //break;
                         }
                     case EntryType.JointIndices:
                         {
-                            var holder = (AnimationJointIndicesHolder)iter;
-                            list.Add(new JsonArrayHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Count = holder.JointIndices.Length
-                            }); ;
-                            break;
+                            continue;
+                            // ?
+                            //break;
                         }
                     case EntryType.FrameData:
                         {
-                            var holder = (AnimationFrameDataHolder)iter;
-                            list.Add(new JsonArrayHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType(),
-                                Count = holder.FrameData.Length
-                            });
-                            break;
+                            continue;
+                            // ?
+                            //break;
                         }
                     case EntryType.Mtx:
+                        child = doc.CreateElement("Mtx");
+                        break;
                     case EntryType.SkeletonHeader:
+                        child = doc.CreateElement("Skeleton");
+                        child.SetAttribute("Type", "Normal");
+                        child.SetAttribute("LimbType", "Standard");
+                        break;
                     case EntryType.FlexSkeletonHeader:
+                        child = doc.CreateElement("Skeleton");
+                        child.SetAttribute("Type", "Flex");
+                        child.SetAttribute("LimbType", "Standard");
+                        break;
                     case EntryType.SkeletonLimb:
+                        child = doc.CreateElement("Limb");
+                        child.SetAttribute("LimbType", "Standard");
+                        break;
                     case EntryType.AnimationHeader:
-                        {
-                            list.Add(new JsonObjectHolder()
-                            {
-                                Name = iter.Name,
-                                EntryType = iter.GetEntryType()
-                            });
-                            break;
-                        }
+                        child = doc.CreateElement("Animation");
+                        break;
                     default:
                         throw new Z64ObjectException($"Invalid entry type ({iter.GetEntryType()})");
                 }
+                child?.SetAttribute("Name", iter.Name);
+                //child?.SetAttribute("Offset", iter.Offset);
+                child?.SetAttribute("Offset", iter.Name.Split("_").Last());
+                file.AppendChild(child);
             }
-            return JsonSerializer.Serialize<object>(list, new JsonSerializerOptions() { WriteIndented = true }) ;
-            */
+            //return JsonSerializer.Serialize<object>(list, new JsonSerializerOptions() { WriteIndented = true }) ;
+            doc.Save(filename);
         }
 
     }

--- a/Z64Utils/Z64/Z64Object.cs
+++ b/Z64Utils/Z64/Z64Object.cs
@@ -12,6 +12,7 @@ using F3DZEX;
 using Syroot.BinaryData;
 using Common;
 using RDP;
+using System.Xml;
 
 namespace Z64
 {
@@ -1129,6 +1130,294 @@ namespace Z64
                 }
             }
             return obj;
+        }
+
+        public static Z64Object FromXml(string filename)
+        {
+            Z64Object obj = new Z64Object();
+            XmlDocument doc = new XmlDocument();
+            doc.Load(filename);
+            XmlElement root = (XmlElement)doc.FirstChild;
+            XmlElement file = (XmlElement)root.FirstChild;
+
+            // TODO: do something with this.
+            string xml_File_Name = file.GetAttributeNode("Name").Value;
+            int xml_File_Segment = Convert.ToInt32(file.GetAttributeNode("Segment").Value);
+            /*
+            // TODO: conditionally check if this attributes exists.
+            string xml_File_BaseAddress = file.GetAttributeNode("BaseAddress").Value;
+            string xml_File_RangeStart = file.GetAttributeNode("RangeStart").Value;
+            string xml_File_RangeEnd = file.GetAttributeNode("RangeEnd").Value;
+            */
+
+            foreach (XmlElement iter in file.ChildNodes)
+            {
+                //iter.GetAttributeNode("");
+                //var type = (EntryType)Enum.Parse(typeof(EntryType), iter.GetProperty(nameof(JsonObjectHolder.EntryType)).GetString());
+                var type = (EntryType)Enum.Parse(typeof(EntryType), iter.Name);
+                string nodeName = iter.GetAttributeNode("Name").Value;
+                int nodeOffset = Convert.ToInt32(iter.GetAttributeNode("Offset").Value, 16);
+
+                if (iter.Name == "DList")
+                {
+                    // TODO: do something with dlist size
+                    obj.AddDList(-1, nodeName, nodeOffset);
+                }
+                else if (iter.Name == "Vtx")
+                {
+                    // TODO: ZAPD usually uses <Array><Vtx/></Array>
+                    /*
+                    var holder = iter.ToObject<JsonVertexHolder>();
+                    obj.AddVertices(holder.VertexCount, holder.Name);
+                    break;
+                    */
+                }
+                else if (iter.Name == "Texture")
+                {
+                    string nodeOutName = iter.GetAttributeNode("OutName").Value;
+                    string nodeFormat = iter.GetAttributeNode("Format").Value;
+                    int nodeWidth = Convert.ToInt32(iter.GetAttributeNode("Width").Value);
+                    int nodeHeight = Convert.ToInt32(iter.GetAttributeNode("Height").Value);
+                    // TODO: parse nodeFormat -> N64TexFormat
+                    //obj.AddTexture(nodeWidth, nodeHeight, nodeFormat, nodeName, nodeOffset);
+                    obj.AddTexture(nodeWidth, nodeHeight, N64TexFormat.IA8, nodeName, nodeOffset);
+                }
+                else if (iter.Name == "Background")
+                {
+                    string nodeOutName = iter.GetAttributeNode("OutName").Value;
+                    // TODO: JPEG prerender
+                }
+                else if (iter.Name == "Blob")
+                {
+                    int nodeSize = Convert.ToInt32(iter.GetAttributeNode("Size").Value, 16);
+                    obj.AddUnknow(nodeSize, nodeName, nodeOffset);
+                }
+                else if (iter.Name == "Scene" || iter.Name == "Room")
+                {
+                    // TODO
+                }
+                else if (iter.Name == "Skeleton")
+                {
+                    string nodeType = iter.GetAttributeNode("Type").Value;
+                    string nodeLimbType = iter.GetAttributeNode("LimbType").Value;
+
+                    if (nodeType == "Normal")
+                    {
+                        obj.AddSkeleton(nodeName, nodeOffset);
+                    }
+                    else if (nodeType == "Flex")
+                    {
+                        obj.AddFlexSkeleton(nodeName, nodeOffset);
+                    }
+                    else if (nodeType == "Curve")
+                    {
+                        // obj.AddCurveSkeleton(nodeName, nodeOffset);
+                    }
+                    
+                    // TODO: Do something with nodeLimbType
+                }
+                else if (iter.Name == "Limb")
+                {
+                    //string nodeType = iter.GetAttributeNode("Type").Value;
+                    var lt = iter.GetAttributeNode("LimbType");
+                    string nodeLimbType;
+                    if (lt != null)
+                    {
+                        nodeLimbType = lt.Value;
+                    }
+                    else
+                    {
+                        nodeLimbType = iter.GetAttributeNode("Type").Value;
+                    }
+                    
+                    obj.AddSkeletonLimb(nodeName, nodeOffset);
+
+                    if (nodeLimbType == "Standard")
+                    {
+                    }
+                    else if (nodeLimbType == "LOD")
+                    {
+                    }
+                    else if (nodeLimbType == "Skin")
+                    {
+                    }
+                    else if (nodeLimbType == "Curve")
+                    {
+                    }
+                    
+                    // TODO: Do something with nodeLimbType
+                }
+                else if (iter.Name == "Symbol")
+                {
+                    // TODO?
+                    string nodeType = iter.GetAttributeNode("Type").Value;
+                    int nodeTypeSize = Convert.ToInt32(iter.GetAttributeNode("TypeSize").Value, 0);
+                    // This one is optional.
+                    //int nodeCount = Convert.ToInt32(iter.GetAttributeNode("Count").Value, 0);
+                }
+                else if (iter.Name == "Collision")
+                {
+                    // TODO
+                }
+                else if (iter.Name == "Scalar")
+                {
+                    // TODO
+                    string nodeType = iter.GetAttributeNode("Type").Value;
+                }
+                else if (iter.Name == "Vector")
+                {
+                    // TODO
+                    string nodeType = iter.GetAttributeNode("Type").Value;
+                    int nodeDimensions = Convert.ToInt32(iter.GetAttributeNode("Dimensions").Value, 16);
+                }
+                else if (iter.Name == "Cutscene")
+                {
+                    // TODO
+                }
+                else if (iter.Name == "Array")
+                {
+                    // TODO
+                    int nodeCount = Convert.ToInt32(iter.GetAttributeNode("Count").Value, 0);
+                }
+                else if (iter.Name == "Animation")
+                {
+                    obj.AddAnimation(nodeName, nodeOffset);
+                }
+                else if (iter.Name == "PlayerAnimation")
+                {
+                    //obj.AddPlayerAnimation(nodeName, nodeOffset);
+                }
+                else if (iter.Name == "CurveAnimation")
+                {
+                    //obj.AddCurveAnimation(nodeName, nodeOffset);
+                }
+                else if (iter.Name == "Mtx")
+                {
+                    obj.AddMtx(1, nodeName, nodeOffset);
+                }
+                else
+                {
+                    throw new Z64ObjectException($"Invalid xml element ({iter.Name})");
+                }
+            }
+            /*
+            for (int i = 0; i < list.Count; i++)
+            {
+                var holder = ((JsonElement)list[i]).ToObject<JsonTextureHolder>();
+                if (holder.EntryType == EntryType.Texture)
+                {
+                    var tlut = (TextureHolder)obj.Entries.Find(e => e.GetEntryType() == EntryType.Texture && e.Name == holder.Tlut);
+                    ((TextureHolder)obj.Entries[i]).Tlut = tlut;
+                }
+            }
+            */
+            return obj;
+        }
+
+        public void WriteXml(string filename)
+        {
+            /*
+            var list = new List<object>();
+            foreach (var iter in Entries)
+            {
+                switch (iter.GetEntryType())
+                {
+                    case EntryType.DList:
+                        {
+                            list.Add(new JsonUCodeHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Size = iter.GetSize()
+                            });
+                            break;
+                        }
+                    case EntryType.Vertex:
+                        {
+                            list.Add(new JsonVertexHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                VertexCount = ((VertexHolder)iter).Vertices.Count,
+                            });
+                            break;
+                        }
+                    case EntryType.Texture:
+                        {
+                            var holder = (TextureHolder)iter;
+                            list.Add(new JsonTextureHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Width = holder.Width,
+                                Height = holder.Height,
+                                Format = holder.Format,
+                                Tlut = holder.Tlut?.Name,
+                            });
+                            break;
+                        }
+                    case EntryType.Unknown:
+                        {
+                            list.Add(new JsonUnknowHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Size = iter.GetSize()
+                            });
+                            break;
+                        }
+                    case EntryType.SkeletonLimbs:
+                        {
+                            var holder = (SkeletonLimbsHolder)iter;
+                            list.Add(new JsonArrayHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Count = holder.LimbSegments.Length
+                            });
+                            break;
+                        }
+                    case EntryType.JointIndices:
+                        {
+                            var holder = (AnimationJointIndicesHolder)iter;
+                            list.Add(new JsonArrayHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Count = holder.JointIndices.Length
+                            }); ;
+                            break;
+                        }
+                    case EntryType.FrameData:
+                        {
+                            var holder = (AnimationFrameDataHolder)iter;
+                            list.Add(new JsonArrayHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType(),
+                                Count = holder.FrameData.Length
+                            });
+                            break;
+                        }
+                    case EntryType.Mtx:
+                    case EntryType.SkeletonHeader:
+                    case EntryType.FlexSkeletonHeader:
+                    case EntryType.SkeletonLimb:
+                    case EntryType.AnimationHeader:
+                        {
+                            list.Add(new JsonObjectHolder()
+                            {
+                                Name = iter.Name,
+                                EntryType = iter.GetEntryType()
+                            });
+                            break;
+                        }
+                    default:
+                        throw new Z64ObjectException($"Invalid entry type ({iter.GetEntryType()})");
+                }
+            }
+            return JsonSerializer.Serialize<object>(list, new JsonSerializerOptions() { WriteIndented = true }) ;
+            */
         }
 
     }


### PR DESCRIPTION
An untested attempt to be compatible with ZAPD's xmls.
I made this based on the current json import/export feature.
- The "Export XML" feature should mostly work and produce a functional xml.
- The "Import XML" may be bugged (from a bit, to a lot).
  - Importing dlists will likely crash. The `AddDList` method expects a size parameter, but ZAPD doesn't need that, so it xmls lacks the dlist size.
  - ZAPD is able to find `JointIndices` and `FrameData` automatically from animations so no need to declare them in xmls, but your json system declared that explicitly, so Z64Utils may not detect that properly.
  - I left lots of `TODO` you may want to look at.

If I can help you in any way, just tell me!
