### PR TITLE
Add .NET download link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The tool recreates the memory map of the ROM like how it would lie in virtual RA
 The Object analyzer is capable of analyzing and finding display lists in a given "object" file (these usually contain assets such as model data, textures, skeletons, etc.) and from there, find and decode the data blocks within the object file.
 
 ## F3DZEX Disassembler
-The tool contains a disassembler that can decode the [F3DZEX](https://wiki.cloudmodding.com/oot/F3DZEX2) commands issued by the game to the RSP. 
+The tool contains a disassembler that can decode the [F3DZEX](https://wiki.cloudmodding.com/oot/F3DZEX2) commands issued by the game to the RSP.
 
 ## Texture Viewer
 The texture viewer supports all the texture formats used by the nintendo 64 RDP (CI4, CI8, I4, I8, IA4, IA8, IA16, RGBA16, RGBA32).
@@ -30,3 +30,21 @@ The Skeleton Viewer can parse and render skeletons and animations used in Ocarin
 
 Note that currently only standart limbs are supported (no SkinLimb/LodLimb)
 
+# Dependencies
+
+Currently, the only requirement is `.NET 5.0.5` (Not to be confused with `.NET Core` or `.NET Framework`).
+
+The general purpouse download link for `.NET` is [this](https://dotnet.microsoft.com/download), and the direct download is [here](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.202-windows-x64-installer).
+
+## Wine / Linux
+
+Z64Utils v2.0.1 is wine-compatible (this may change in the future).
+
+To run it, first you need to install `.NET 5.0.5` using the installer (see [Dependencies](#dependencies) for the download link).
+
+Please keep in mind you need to use `wine64` instead of `wine` because this is a 64bits-only app.
+
+```bash
+wine64 dotnet-sdk-5.0.202-win-x64.exe
+wine64 Z64Utils.exe
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Note that currently only standart limbs are supported (no SkinLimb/LodLimb)
 
 Currently, the only requirement is `.NET 5.0.5` (Not to be confused with `.NET Core` or `.NET Framework`).
 
-The general purpouse download link for `.NET` is [this](https://dotnet.microsoft.com/download), and the direct download is [here](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.202-windows-x64-installer).
+The general purpose download link for `.NET` is [this](https://dotnet.microsoft.com/download), and the direct download is [here](https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.202-windows-x64-installer).
 
 ## Wine / Linux
 


### PR DESCRIPTION
Add the download link for the required .NET version to readme, so people don't have problems with it.

Also added a small section with instructions to run Z64Utils in wine.