### PR TITLE
Partially import Zapd-style XML descriptions of files

### DIFF
--- a/Z64Utils/Common/Filters.cs
+++ b/Z64Utils/Common/Filters.cs
@@ -13,6 +13,7 @@ namespace Common
         public const string N64 = "N64 Rom(*.n64; *.z64)|*.n64;*.z64";
         public const string BIN = "Bin Files (*.bin)|*.bin";
         public const string JSON = "JSON Files (*.json)|*.json";
+        public const string XML = "XML Files (*.xml)|*.xml";
         public const string C = "C Files (*.c)|*.c";
     }
 }

--- a/Z64Utils/Forms/ObjectAnalyzerForm.Designer.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.Designer.cs
@@ -74,6 +74,7 @@
             this.analyzeDlistsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.importJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importZapdXmlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disassemblySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -386,6 +387,7 @@
             this.analyzeDlistsToolStripMenuItem,
             this.importJSONToolStripMenuItem,
             this.exportJSONToolStripMenuItem,
+            this.importZapdXmlToolStripMenuItem,
             this.resetToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.Size = new System.Drawing.Size(62, 20);
@@ -420,6 +422,13 @@
             this.exportJSONToolStripMenuItem.Size = new System.Drawing.Size(220, 22);
             this.exportJSONToolStripMenuItem.Text = "Export JSON";
             this.exportJSONToolStripMenuItem.Click += new System.EventHandler(this.exportJSONToolStripMenuItem_Click);
+            // 
+            // importZapdXmlToolStripMenuItem
+            // 
+            this.importZapdXmlToolStripMenuItem.Name = "importZapdXmlToolStripMenuItem";
+            this.importZapdXmlToolStripMenuItem.Size = new System.Drawing.Size(220, 22);
+            this.importZapdXmlToolStripMenuItem.Text = "Import ZapdXml";
+            this.importZapdXmlToolStripMenuItem.Click += new System.EventHandler(this.importZapdXmlToolStripMenuItem_Click);
             // 
             // resetToolStripMenuItem
             // 
@@ -508,6 +517,7 @@
         private System.Windows.Forms.ColumnHeader columnHeader8;
         private System.Windows.Forms.ToolStripMenuItem importJSONToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportJSONToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importZapdXmlToolStripMenuItem;
         private System.Windows.Forms.SaveFileDialog saveFileDialog1;
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;

--- a/Z64Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.cs
@@ -131,7 +131,7 @@ namespace Z64.Forms
                 return;
             }
 
-            openInDlistViewerMenuItem.Visible = 
+            openInDlistViewerMenuItem.Visible =
             addToDlistViewerMenuItem.Visible =
             openSkeletonViewerMenuItem.Visible = false;
 
@@ -197,7 +197,7 @@ namespace Z64.Forms
                                 var values = "";
                                 for (int j = 0; j < 4; j++)
                                 {
-                                    values += $"0x{ArrayUtil.ReadUint32BE(matrices.Matrices[n].GetBuffer(), 4*(4 * i + j)):X08}";
+                                    values += $"0x{ArrayUtil.ReadUint32BE(matrices.Matrices[n].GetBuffer(), 4 * (4 * i + j)):X08}";
                                     if (j != 3)
                                         values += $"  ";
                                 }
@@ -292,7 +292,7 @@ namespace Z64.Forms
                     {
                         tabControl1.SelectedTab = tabPage_unknow;
 
-                        var provider = new DynamicByteProvider(holder.GetData());;
+                        var provider = new DynamicByteProvider(holder.GetData());
                         hexBox1.ByteProvider = provider;
                         hexBox1.LineInfoOffset = new SegmentedAddress(_segment, _obj.OffsetOf(holder)).VAddr;
                         break;
@@ -331,7 +331,7 @@ namespace Z64.Forms
             UpdateMap();
         }
 
-        
+
 
         private void openSkeletonViewerMenuItem_Click(object sender, EventArgs e)
         {
@@ -438,6 +438,19 @@ namespace Z64.Forms
             }
         }
 
+        private void importZapdXmlToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            openFileDialog1.FileName = "";
+            openFileDialog1.Filter = $"{Filters.XML}|{Filters.ALL}";
+            if (openFileDialog1.ShowDialog() == DialogResult.OK)
+            {
+                string xml = File.ReadAllText(openFileDialog1.FileName);
+                _obj = Z64Object.FromZapdXml(xml);
+                _obj.SetData(_data);
+                UpdateMap();
+            }
+        }
+
         private void exportCToolStripMenuItem_Click(object sender, EventArgs e)
         {
             saveFileDialog1.FileName = "";
@@ -478,7 +491,7 @@ namespace Z64.Forms
                                 sw.WriteLine($"u8 {entry.Name}[] = \r\n{{");
 
                                 var tex = entry.GetData();
-                                for (int i = 0; i < tex.Length; i+= 16)
+                                for (int i = 0; i < tex.Length; i += 16)
                                 {
                                     sw.Write("    ");
                                     for (int j = 0; j < 16 && i + j < tex.Length; j++)
@@ -497,7 +510,7 @@ namespace Z64.Forms
                                 for (int i = 0; i < bytes.Length; i += 16)
                                 {
                                     sw.Write("    ");
-                                    for (int j = 0; j < 16 && i+j < bytes.Length; j++)
+                                    for (int j = 0; j < 16 && i + j < bytes.Length; j++)
                                         sw.Write($"0x{bytes[i + j]:X2}, ");
                                     sw.Write("\r\n");
                                 }
@@ -518,7 +531,7 @@ namespace Z64.Forms
                                 for (int i = 0; i < 8; i += 8)
                                 {
                                     sw.Write("    ");
-                                    for (int j = 0; j < 8 && i+j < holder.FrameData.Length; j++)
+                                    for (int j = 0; j < 8 && i + j < holder.FrameData.Length; j++)
                                         sw.Write($"0x{holder.FrameData[i + j]:X4}, ");
                                 }
                                 sw.WriteLine("};");

--- a/Z64Utils/Z64/Z64Object.cs
+++ b/Z64Utils/Z64/Z64Object.cs
@@ -933,6 +933,8 @@ namespace Z64
                         iter.SetData(br.ReadBytes(iter.GetSize()));
                     }
                 }
+
+                Entries.RemoveAll(entry => entry.GetSize() == 0);
             }
         }
         public byte[] Build()


### PR DESCRIPTION
This isn't a real formal PR, I more just want to know what you think. I never did any C# before this either so feel free to comment lots

Apparently `ObjectAnalyzerForm.Designer.cs` should not be tinkered with by hand but I did, I'd appreciate you linking me to some tutorial for whatever I'm supposed to do to edit it

There's a bunch of random changes too due to running code formatting

------

This imports Skeleton, Animation, DList and Texture offsets from Zapd-style XML files such as found [in the oot decomp repo](https://github.com/zeldaret/oot/tree/master/assets/xml)

Since those XML usually don't set the size of each part of the data, I coded a dirty thing that detects the size of a dlist

With [object_mb](https://github.com/zeldaret/oot/blob/201c9ec1cdbc3baffd7cc5520d4f6e1f47093b7e/assets/xml/objects/object_mb.xml) (Moblin):

![object_mb](https://421.es/doyu/227mfr)