### PR TITLE
Fix CI4 decoding

### DIFF
--- a/Z64Utils/N64/N64Texture.cs
+++ b/Z64Utils/N64/N64Texture.cs
@@ -384,21 +384,21 @@ namespace N64
             byte[] ret = new byte[texels * 4];
             for (int t = 0; t < inBuff.Length; t++)
             {
-                byte idx = (byte)(inBuff[t] & 0xF);
+                byte idx = (byte)(inBuff[t] >> 4 & 0xF);
                 byte b1 = tlut[2 * idx + 0];
                 byte b2 = tlut[2 * idx + 1];
-                ret[4 * t + 0] = (byte)((b1 >> 3) * 0xFF / 0x1F);
-                ret[4 * t + 1] = (byte)((((b1 & 7) << 2) | (b2 >> 6)) * 0xFF / 0x1F);
-                ret[4 * t + 2] = (byte)(((b2 >> 1) & 0x1F) * 0xFF / 0x1F);
-                ret[4 * t + 3] = (byte)(0xFF * (b2 & 1));
+                ret[8 * t + 0] = (byte)((b1 >> 3) * 0xFF / 0x1F);
+                ret[8 * t + 1] = (byte)((((b1 & 7) << 2) | (b2 >> 6)) * 0xFF / 0x1F);
+                ret[8 * t + 2] = (byte)(((b2 >> 1) & 0x1F) * 0xFF / 0x1F);
+                ret[8 * t + 3] = (byte)(0xFF * (b2 & 1));
 
-                idx = (byte)(inBuff[t] >> 4 & 0xF);
+                idx = (byte)(inBuff[t] & 0xF);
                 b1 = tlut[2 * idx + 0];
                 b2 = tlut[2 * idx + 1];
-                ret[4 * t + 4] = (byte)((b1 >> 3) * 0xFF / 0x1F);
-                ret[4 * t + 5] = (byte)((((b1 & 7) << 2) | (b2 >> 6)) * 0xFF / 0x1F);
-                ret[4 * t + 6] = (byte)(((b2 >> 1) & 0x1F) * 0xFF / 0x1F);
-                ret[4 * t + 7] = (byte)(0xFF * (b2 & 1));
+                ret[8 * t + 4] = (byte)((b1 >> 3) * 0xFF / 0x1F);
+                ret[8 * t + 5] = (byte)((((b1 & 7) << 2) | (b2 >> 6)) * 0xFF / 0x1F);
+                ret[8 * t + 6] = (byte)(((b2 >> 1) & 0x1F) * 0xFF / 0x1F);
+                ret[8 * t + 7] = (byte)(0xFF * (b2 & 1));
             }
 
             return ret;

--- a/Z64Utils/N64/N64Texture.cs
+++ b/Z64Utils/N64/N64Texture.cs
@@ -273,17 +273,17 @@ namespace N64
             for (int t = 0; t < inBuff.Length; t++)
             {
                 byte b = (byte)((inBuff[t] >> 4) * 0x11);
-                ret[t * 4 + 0] = b;
-                ret[t * 4 + 1] = b;
-                ret[t * 4 + 2] = b;
-                ret[t * 4 + 3] = 0xFF;
+                ret[t * 8 + 0] = b;
+                ret[t * 8 + 1] = b;
+                ret[t * 8 + 2] = b;
+                ret[t * 8 + 3] = 0xFF;
                 //ret[t * 4 + 3] = b;
 
                 b = (byte)((inBuff[t] & 0xF) * 0x11);
-                ret[t * 4 + 4] = b;
-                ret[t * 4 + 5] = b;
-                ret[t * 4 + 6] = b;
-                ret[t * 4 + 7] = 0xFF;
+                ret[t * 8 + 4] = b;
+                ret[t * 8 + 5] = b;
+                ret[t * 8 + 6] = b;
+                ret[t * 8 + 7] = 0xFF;
                 //ret[t * 4 + 7] = b;
             }
 
@@ -320,18 +320,18 @@ namespace N64
                 byte b = (byte)(inBuff[t] >> 4);
                 byte i = (byte)((b >> 1) * 0xFF / 0b111);
                 byte a = (byte)((b & 1) * 0xFF);
-                ret[t * 4 + 0] = i;
-                ret[t * 4 + 1] = i;
-                ret[t * 4 + 2] = i;
-                ret[t * 4 + 3] = a;
+                ret[t * 8 + 0] = i;
+                ret[t * 8 + 1] = i;
+                ret[t * 8 + 2] = i;
+                ret[t * 8 + 3] = a;
 
                 b = (byte)((inBuff[t] & 0xF) * 0x11);
                 i = (byte)((b >> 1) * 0xFF / 0b111);
                 a = (byte)((b & 1) * 0xFF);
-                ret[t * 4 + 4] = i;
-                ret[t * 4 + 5] = i;
-                ret[t * 4 + 6] = i;
-                ret[t * 4 + 7] = a;
+                ret[t * 8 + 4] = i;
+                ret[t * 8 + 5] = i;
+                ret[t * 8 + 6] = i;
+                ret[t * 8 + 7] = a;
             }
 
             return ret;


### PR DESCRIPTION
There are (were) two issues in `DecodeCI4`, stepping by 4 instead of 8 each iteration and reading the color indices in the wrong order

I don't know how you handle your branches, hopefully you can merge this into dev if that's preferred

EDIT: found same issue of 4-stepping in DecodeI4 and DecodeIA4