### PR TITLE
Allow loading a single file into the object analyzer

### DIFF
--- a/Z64Utils/Forms/MainForm.Designer.cs
+++ b/Z64Utils/Forms/MainForm.Designer.cs
@@ -66,6 +66,7 @@ namespace Z64.Forms
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.openObjectToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.contextMenuStrip_fs.SuspendLayout();
@@ -234,7 +235,8 @@ namespace Z64.Forms
             this.romExportFsItem,
             this.romSaveItem,
             this.romImportNamesItem,
-            this.romExportNamesItem});
+            this.romExportNamesItem,
+            this.openObjectToolStripMenuItem1});
             this.romToolStripButton.Image = global::Z64.Properties.Resources.file;
             this.romToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.romToolStripButton.Name = "romToolStripButton";
@@ -350,6 +352,13 @@ namespace Z64.Forms
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
+            // openObjectToolStripMenuItem1
+            // 
+            this.openObjectToolStripMenuItem1.Name = "openObjectToolStripMenuItem1";
+            this.openObjectToolStripMenuItem1.Size = new System.Drawing.Size(234, 26);
+            this.openObjectToolStripMenuItem1.Text = "Open Object";
+            this.openObjectToolStripMenuItem1.Click += new System.EventHandler(this.openObjectToolStripMenuItem1_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -410,6 +419,7 @@ namespace Z64.Forms
         private System.Windows.Forms.ToolStripDropDownButton toolsToolStripButton;
         private System.Windows.Forms.ToolStripDropDownButton helpToolStripButton;
         private System.Windows.Forms.ToolStripMenuItem romExportNamesItem;
+        private System.Windows.Forms.ToolStripMenuItem openObjectToolStripMenuItem1;
     }
 }
 

--- a/Z64Utils/Forms/MainForm.cs
+++ b/Z64Utils/Forms/MainForm.cs
@@ -115,6 +115,36 @@ namespace Z64.Forms
             listView_files.EndUpdate();
         }
 
+        private void OpenObjectAnalyzer(Z64Game game, string fileName, byte[] data, string title)
+        {
+            int defaultSegment = -1;
+
+            if (fileName.StartsWith("object_"))
+                defaultSegment = 6;
+            else if (fileName.Contains("_room_"))
+                defaultSegment = 3;
+            else if (fileName.EndsWith("_scene"))
+                defaultSegment = 2;
+            else if (fileName == "gameplay_keep")
+                defaultSegment = 4;
+            else if (fileName.StartsWith("gameplay_"))
+                defaultSegment = 5;
+
+            var valueForm = new EditValueForm("Choose Segment", "Plase enter a segment id.", (v) =>
+            {
+                return (int.TryParse(v, out int ret) && ret >= 0 && ret < 16)
+                ? null
+                : "Segment ID must be a value between 0 and 15";
+            }, defaultSegment < 0 ? "" : $"{defaultSegment}");
+
+            if (valueForm.ShowDialog() == DialogResult.OK)
+            {
+                var form = new ObjectAnalyzerForm(game, data, int.Parse(valueForm.Result));
+                form.Text += $" - {title}";
+                form.Show();
+            }
+        }
+
         private void RomOpenItem_Click(object sender, EventArgs e)
         {
             openFileDialog1.FileName = "";
@@ -282,33 +312,9 @@ namespace Z64.Forms
                 return;
             }
 
-
-            string defaultValue = null;
             string fileName = _game.GetFileName(file.VRomStart).ToLower();
-
-            if (fileName.StartsWith("object_"))
-                defaultValue = "6";
-            else if (fileName.Contains("_room_"))
-                defaultValue = "3";
-            else if (fileName.EndsWith("_scene"))
-                defaultValue = "2";
-            else if (fileName == "gameplay_keep")
-                defaultValue = "4";
-            else if (fileName.StartsWith("gameplay_"))
-                defaultValue = "5";
-
-            var valueForm = new EditValueForm("Choose Segment", "Plase enter a segment id.", (v) =>
-            {
-                return (int.TryParse(v, out int ret) && ret >= 0 && ret < 16)
-                ? null
-                : "Segment ID must be a value between 0 and 15";
-            }, defaultValue);
-            if (valueForm.ShowDialog() == DialogResult.OK)
-            {
-                var form = new ObjectAnalyzerForm(_game, file.Data, int.Parse(valueForm.Result));
-                form.Text += $" - \"{_game.GetFileName(file.VRomStart)}\" ({file.VRomStart:X8}-{file.VRomEnd:X8})";
-                form.Show();
-            }
+            string title = $"\"{_game.GetFileName(file.VRomStart)}\" ({file.VRomStart:X8}-{file.VRomEnd:X8})";
+            OpenObjectAnalyzer(_game, fileName, file.Data, title);
         }
 
         private void renameToolStripMenuItem_Click(object sender, EventArgs e)
@@ -372,5 +378,18 @@ namespace Z64.Forms
                 MessageBox.Show("No new release available.");
         }
 
+        private void openObjectToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            openFileDialog1.FileName = "";
+            openFileDialog1.Filter = $"{Filters.ALL}";
+            if (openFileDialog1.ShowDialog() == DialogResult.OK)
+            {
+                string filePath = openFileDialog1.FileName;
+                string fileName = Path.GetFileName(filePath);
+                byte[] data = File.ReadAllBytes(filePath);
+                string title = $" - {filePath}";
+                OpenObjectAnalyzer(null, fileName, data, title);
+            }
+        }
     }
 }

--- a/Z64Utils/Forms/MainForm.cs
+++ b/Z64Utils/Forms/MainForm.cs
@@ -387,7 +387,7 @@ namespace Z64.Forms
                 string filePath = openFileDialog1.FileName;
                 string fileName = Path.GetFileName(filePath);
                 byte[] data = File.ReadAllBytes(filePath);
-                string title = $" - {filePath}";
+                string title = $"{filePath}";
                 OpenObjectAnalyzer(null, fileName, data, title);
             }
         }


### PR DESCRIPTION
This is very useful for using Z64Utils in modding scenarios, for debugging a generated object or view already extracted files.

`(Z64Game)null` is passed to the `ObjectAnalyzerForm` constructor. It seems that having a non-`null` `Z64Game` instance isn't critical, and there already are `!= null` checks where it matters, so this seems fine.

Again Visual Studio Designer decided to change a whole bunch of stuff when I added the menu item, I only commited the relevant changes. Works fine on my end

![](https://421.es/doyu/254x8r)