### PR TITLE
[Object Analyzer] Fix display of Mtx holder

### DIFF
--- a/Z64Utils/Common/ArrayUtil.cs
+++ b/Z64Utils/Common/ArrayUtil.cs
@@ -8,6 +8,12 @@ namespace Common
 {
     class ArrayUtil
     {
+        public static int ReadInt32BE(byte[] data, int offset = 0)
+        {
+            byte[] buff = new byte[sizeof(int)];
+            Buffer.BlockCopy(data, offset, buff, 0, sizeof(int));
+            return BitConverter.ToInt32(buff.Reverse().ToArray(), 0);
+        }
         public static uint ReadUint32BE(byte[] data, int offset = 0)
         {
             byte[] buff = new byte[sizeof(uint)];

--- a/Z64Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.cs
@@ -244,29 +244,22 @@ namespace Z64.Forms
                         StringWriter sw = new StringWriter();
                         for (int n = 0; n < matrices.Matrices.Count; n++)
                         {
+                            var mtx = new Mtx(matrices.Matrices[n].GetBuffer()).ToMatrix4();
                             string[,] mtxStr = new string[4, 4];
                             int[] columnsWidth = { 0, 0, 0, 0 };
                             for (int i = 0; i < 4; i++)
                             {
                                 for (int j = 0; j < 4; j++)
                                 {
-                                    // see Matrix_MtxToMtxF
-                                    int elemIndex = 4 * j + i;
-                                    byte[] buffer = matrices.Matrices[n].GetBuffer();
-                                    byte[] bytes = {
-                                        // integer part
-                                        buffer[2 * elemIndex], buffer[2 * elemIndex + 1],
-                                        // fractional part
-                                        buffer[2 * (4 * 4 + elemIndex)], buffer[2 * (4 * 4 + elemIndex) + 1],
-                                    };
-                                    float val = ArrayUtil.ReadInt32BE(bytes) / (float)0x10000;
+                                    float val = mtx[j, i]; // Matrix4 uses column-major order
                                     string valStr = $"{val}";
                                     mtxStr[i,j] = valStr;
                                     columnsWidth[j] = Math.Max(valStr.Length, columnsWidth[j]);
                                 }
                             }
 
-                            int w = 6;
+                            string columnSeparator = "  ";
+                            int w = 3 * columnSeparator.Length;
                             for (int j = 0; j < 4; j++)
                                 w += columnsWidth[j];
                             sw.WriteLine(" ┌ " + new string(' ', w) + " ┐ ");
@@ -277,7 +270,7 @@ namespace Z64.Forms
                                 {
                                     values += mtxStr[i, j].PadLeft(columnsWidth[j]);
                                     if (j != 3)
-                                        values += $"  ";
+                                        values += columnSeparator;
                                 }
                                 sw.WriteLine($" │ {values} │ ");
                             }

--- a/Z64Utils/Forms/ObjectAnalyzerForm.cs
+++ b/Z64Utils/Forms/ObjectAnalyzerForm.cs
@@ -244,19 +244,44 @@ namespace Z64.Forms
                         StringWriter sw = new StringWriter();
                         for (int n = 0; n < matrices.Matrices.Count; n++)
                         {
-                            sw.WriteLine($" ┌                                                ┐ ");
+                            string[,] mtxStr = new string[4, 4];
+                            int[] columnsWidth = { 0, 0, 0, 0 };
+                            for (int i = 0; i < 4; i++)
+                            {
+                                for (int j = 0; j < 4; j++)
+                                {
+                                    // see Matrix_MtxToMtxF
+                                    int elemIndex = 4 * j + i;
+                                    byte[] buffer = matrices.Matrices[n].GetBuffer();
+                                    byte[] bytes = {
+                                        // integer part
+                                        buffer[2 * elemIndex], buffer[2 * elemIndex + 1],
+                                        // fractional part
+                                        buffer[2 * (4 * 4 + elemIndex)], buffer[2 * (4 * 4 + elemIndex) + 1],
+                                    };
+                                    float val = ArrayUtil.ReadInt32BE(bytes) / (float)0x10000;
+                                    string valStr = $"{val}";
+                                    mtxStr[i,j] = valStr;
+                                    columnsWidth[j] = Math.Max(valStr.Length, columnsWidth[j]);
+                                }
+                            }
+
+                            int w = 6;
+                            for (int j = 0; j < 4; j++)
+                                w += columnsWidth[j];
+                            sw.WriteLine(" ┌ " + new string(' ', w) + " ┐ ");
                             for (int i = 0; i < 4; i++)
                             {
                                 var values = "";
                                 for (int j = 0; j < 4; j++)
                                 {
-                                    values += $"0x{ArrayUtil.ReadUint32BE(matrices.Matrices[n].GetBuffer(), 4*(4 * i + j)):X08}";
+                                    values += mtxStr[i, j].PadLeft(columnsWidth[j]);
                                     if (j != 3)
                                         values += $"  ";
                                 }
                                 sw.WriteLine($" │ {values} │ ");
                             }
-                            sw.WriteLine($" └                                                ┘ ");
+                            sw.WriteLine(" └ " + new string(' ', w) + " ┘ ");
                         }
                         textBox_holderInfo.Text = sw.ToString();
                         break;


### PR DESCRIPTION
This fixes displaying Mtx holders in the object analyzer

(didn't test with several matrices, only 1, I assume it should work fine though)

example with `gLinkChildDekuShieldMtx`

```c
Mtx gLinkChildDekuShieldMtx = { 
    0x0000FFFF , 0          , 0xFFFFFFFF , 0xFFFF0000 ,
    0          , 0xFFFF0000 , 0x0258FF9C , 0x00320001 ,
    0x21B4023D , 0          , 0xF136FE0A , 0x00710000 ,
    0xFD5421A5 , 0xF1140000 , 0          , 0          ,
}; 
```

![](https://421.es/doyu/262pa6)

Sources:
[`Matrix_MtxToMtxF` in oot decomp](https://github.com/zeldaret/oot/blob/430a172183fe6f7fe5781325386803e3f1f975cd/src/code/sys_matrix.c#L655)
[`gSPMatrix` in the sdk](http://n64devkit.square7.ch/n64man/gsp/gSPMatrix.htm)